### PR TITLE
Remove link to default nginx site

### DIFF
--- a/scripts/installation-ubuntu-16.04.sh
+++ b/scripts/installation-ubuntu-16.04.sh
@@ -59,6 +59,7 @@ chown www-data:www-data -R bootstrap/cache public/uploads storage && chmod -R 75
 curl https://raw.githubusercontent.com/BookStackApp/devops/master/config/nginx > /etc/nginx/sites-available/bookstack
 sed -i.bak "s/bookstack.dev/$DOMAIN/" /etc/nginx/sites-available/bookstack
 ln -s /etc/nginx/sites-available/bookstack /etc/nginx/sites-enabled/bookstack
+rm /etc/nginx/sites-enabled/default
 
 # Restart nginx to load new config
 service nginx restart


### PR DESCRIPTION
After running installation script on Ubuntu 16.04 BookStack is not available, but nginx show the welcome page. Removing link to default site solve the problem, but maybe another solution will be the best?