### PR TITLE
Allow passing domain as argument

### DIFF
--- a/scripts/installation-ubuntu-18.04.sh
+++ b/scripts/installation-ubuntu-18.04.sh
@@ -2,9 +2,13 @@
 # This script will install a new BookStack instance on a fresh Ubuntu 18.04 server.
 # This script is experimental and does not ensure any security.
 
+DOMAIN=$1
+if [ -z $1 ]
+then
 echo ""
 printf "Enter the domain you want to host BookStack and press [ENTER]\nExamples: my-site.com or docs.my-site.com\n"
 read DOMAIN
+fi
 
 CURRENT_IP=$(ip addr | grep 'state UP' -A2 | tail -n1 | awk '{print $2}' | cut -f1  -d'/')
 


### PR DESCRIPTION
Allows passing the domain as an argument. If missing asked as it did before.