### PR TITLE
fixed multiple packages not being found

### DIFF
--- a/scripts/installation-ubuntu-18.04.sh
+++ b/scripts/installation-ubuntu-18.04.sh
@@ -9,6 +9,7 @@ read DOMAIN
 CURRENT_IP=$(ip addr | grep 'state UP' -A2 | tail -n1 | awk '{print $2}' | cut -f1  -d'/')
 
 export DEBIAN_FRONTEND=noninteractive
+add-apt-repository universe
 apt update
 apt install -y git apache2 curl php7.2-fpm php7.2-curl php7.2-mbstring php7.2-ldap \
 php7.2-tidy php7.2-xml php7.2-zip php7.2-gd php7.2-mysql mysql-server-5.7 libapache2-mod-php7.2


### PR DESCRIPTION
The script as it was would error out and not find installation candidates for many of the packages, such as "php7.2-fpm".

This is because on Ubuntu 18.04, the universe repo is not enabled by default. We have to enable it to get access to these packages.