### PR TITLE
Use newer PHP version from PPA in Ubuntu 16.04 script

### DIFF
--- a/config/nginx
+++ b/config/nginx
@@ -13,6 +13,6 @@ server {
   
   location ~ \.php$ {
     include snippets/fastcgi-php.conf;
-    fastcgi_pass unix:/run/php/php7.0-fpm.sock;
+    fastcgi_pass unix:/run/php/php7.3-fpm.sock;
   }
 }

--- a/scripts/installation-ubuntu-16.04.sh
+++ b/scripts/installation-ubuntu-16.04.sh
@@ -10,8 +10,10 @@ myip=$(ip addr | grep 'state UP' -A2 | tail -n1 | awk '{print $2}' | cut -f1  -d
 
 export DEBIAN_FRONTEND=noninteractive
 apt update
-apt install -y git nginx curl php7.0-fpm php7.0-curl php7.0-mbstring php7.0-ldap php7.0-mcrypt \
-php7.0-tidy php7.0-xml php7.0-zip php7.0-gd php7.0-mysql mysql-server-5.7 mcrypt
+apt install -y software-properties-common python-software-properties
+add-apt-repository -yu ppa:ondrej/php
+apt install -y git nginx curl php7.3-fpm php7.3-curl php7.3-mbstring php7.3-ldap \
+php7.3-tidy php7.3-xml php7.3-zip php7.3-gd php7.3-mysql mysql-server-5.7
 
 # Set up database
 DB_PASS="$(head /dev/urandom | tr -dc A-Za-z0-9 | head -c 13)"


### PR DESCRIPTION
This installs PHP 7.3 from a PPA for Ubuntu 16.04 LTS.
I've tested the new script in a Ubuntu Server 16.04 LTS virtual machine.

btw: the CentOS 7 script already installs PHP 7.3 so there's no need to update the script.